### PR TITLE
Added the 'Markdown Emojicode (GitHub)' column to aid on the commit message writing

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,25 +19,25 @@ For commits with multiple types of messages, use multiple lines:
 
 ## Which Emoji to Use? ❓
 
-Commit Type | Emoji
-----------  | -----
-Initial Commit | [🎉 Party Popper](http://emojipedia.org/party-popper/)
-Version Tag | [🔖 Bookmark](http://emojipedia.org/bookmark/)
-New Feature | [✨ Sparkles](http://emojipedia.org/sparkles/)
-Bugfix | [🐛 Bug](http://emojipedia.org/bug/)
-Security Fix | [🔒 Lock](https://emojipedia.org/lock/)
-Metadata | [📇 Card Index](http://emojipedia.org/card-index/)
-Refactoring | [♻️ Black Universal Recycling Symbol](http://emojipedia.org/black-universal-recycling-symbol/)
-Documentation | [📚 Books](http://emojipedia.org/books/)
-Internationalization | [🌐 Globe With Meridians](http://emojipedia.org/globe-with-meridians/)
-Accessibility | [♿ Wheelchair](https://emojipedia.org/wheelchair-symbol/)
-Performance | [🐎 Horse](http://emojipedia.org/horse/)
-Cosmetic | [🎨 Artist Palette](http://emojipedia.org/artist-palette/)
-Tooling | [🔧 Wrench](http://emojipedia.org/wrench/)
-Tests | [🚨 Police Cars Revolving Light](http://emojipedia.org/police-cars-revolving-light/)
-Deprecation | [💩 Pile of Poo](http://emojipedia.org/pile-of-poo/)
-Removal | [🗑️ Wastebasket](http://emojipedia.org/wastebasket/)
-Work In Progress (WIP) | [🚧 Construction Sign](http://emojipedia.org/construction-sign/)
+Commit Type | Emoji | Markdown Emojicode (GitHub)
+----------  | ----- | ---------------------------
+Initial Commit | [🎉 Party Popper](http://emojipedia.org/party-popper/) | `:tada:`
+Version Tag | [🔖 Bookmark](http://emojipedia.org/bookmark/) | `:bookmark:`
+New Feature | [✨ Sparkles](http://emojipedia.org/sparkles/) | `:sparkles:`
+Bugfix | [🐛 Bug](http://emojipedia.org/bug/) | `:bug:`
+Security Fix | [🔒 Lock](https://emojipedia.org/lock/) | `:lock:`
+Metadata | [📇 Card Index](http://emojipedia.org/card-index/) | `:card_index:`
+Refactoring | [♻️ Black Universal Recycling Symbol](http://emojipedia.org/black-universal-recycling-symbol/) | `:recycle:`
+Documentation | [📚 Books](http://emojipedia.org/books/) | `:books:`
+Internationalization | [🌐 Globe With Meridians](http://emojipedia.org/globe-with-meridians/) | `:globe_with_meridians:`
+Accessibility | [♿ Wheelchair](https://emojipedia.org/wheelchair-symbol/) | `:wheelchair:`
+Performance | [🐎 Horse](http://emojipedia.org/horse/) | `:racehorse:`
+Cosmetic | [🎨 Artist Palette](http://emojipedia.org/artist-palette/) | `:art:`
+Tooling | [🔧 Wrench](http://emojipedia.org/wrench/) | `:wrench:`
+Tests | [🚨 Police Cars Revolving Light](http://emojipedia.org/police-cars-revolving-light/) | `:rotating_light:`
+Deprecation | [💩 Pile of Poo](http://emojipedia.org/pile-of-poo/) | `:hankey:`
+Removal | [🗑️ Wastebasket](http://emojipedia.org/wastebasket/) | `:wastebasket:`
+Work In Progress (WIP) | [🚧 Construction Sign](http://emojipedia.org/construction-sign/) | `:construction:`
 
 ## Using Emoji is Hard! 😡
 


### PR DESCRIPTION
I've been using these emojis for a long time to bring life to my commits 😀
This selection of emojis is very good, and for me, it covers all possibilities of commit types 👌

However, when we need an emoji (despite the possibilities described in INTEGRATIONS.md), we have to enter on the emoji link, which redirects us to emojipedia.org, and copy it.

So I added the `Markdown Emojicode (GitHub)` column to help on the commit message writing.